### PR TITLE
Add janet to Emacs list of interpreters.

### DIFF
--- a/janet-mode.el
+++ b/janet-mode.el
@@ -407,5 +407,8 @@ STATE is the `parse-partial-sexp' state for that position."
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.janet\\'" . janet-mode))
 
+;;;###autoload
+(add-to-list 'interpreter-mode-alist '("janet" . janet-mode))
+
 (provide 'janet-mode)
 ;;; janet-mode.el ends here


### PR DESCRIPTION
Greetings!

This will load janet-mode automatically for any script which has a shebang line referencing "janet". This is useful especially when scripts do not have an extension, including Janet's own `jpm`.