### PR TITLE
Improve handling of long-strings and long-buffers

### DIFF
--- a/janet-mode.el
+++ b/janet-mode.el
@@ -58,9 +58,14 @@ For START and END info, see docs for `syntax-propertize-function'."
    (syntax-propertize-rules
     ((rx (not "`")
          (group "`")
-         (group (* "`")
-                (+ (not "`"))
-                (* "`"))
+         (* "`")
+	 (+ (or (group (not (or ?\s ?\n ?\r ?\t ?\f ?\v
+				?\( ?\)
+				?\[ ?\]
+				?\{ ?\}
+				"`")))
+		(not "`")))
+         (* "`")
          (group "`")
          (not "`"))
      (1 "|")


### PR DESCRIPTION
This PR is an attempt to fix #9, but also improve working with rainbow-delimiters [1].

For background, please see [this comment](https://github.com/ALSchwalm/janet-mode/issues/9#issuecomment-1498308930).  That describes an approach that seems to be working in [janet-ts-mode](https://github.com/sogaiu/janet-ts-mode).

In [this comment](https://github.com/ALSchwalm/janet-mode/issues/9#issuecomment-1498639476), there is a description of how that approach was adapted to janet-mode along with some details of where #11 and #12 didn't quite manage to address a certain type of case.

Note that, this work is based on #11 by @yrns and #12 by @AlbertoGP.  The content of those PRs was helpful in arriving at the approach in this PR.  Many thanks to their efforts :+1: 

---

[1] Please see [this set of files](https://github.com/sogaiu/janet-ts-mode/tree/a96c281e85a158260a416ad4624f6d3671108cde/rainbow-delimiters-test-samples) for specific example source that this PR should handle correctly.